### PR TITLE
Устинов Александр. Задание 3. Вариант 10. Вычисление многомерных интегралов методом Монте-Карло.

### DIFF
--- a/modules/task_3/ustinov_a_multiple_integral_monte_carlo/CMakeLists.txt
+++ b/modules/task_3/ustinov_a_multiple_integral_monte_carlo/CMakeLists.txt
@@ -1,0 +1,71 @@
+get_filename_component(ProjectId ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+enable_testing()
+
+if( USE_MPI )
+    if( UNIX )
+        set(CMAKE_C_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+        set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+    endif( UNIX )
+
+    set(ProjectId "${ProjectId}_mpi")
+    project( ${ProjectId} )
+    message( STATUS "-- " ${ProjectId} )
+
+    file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.h)
+
+    set(PACK_LIB "${ProjectId}_lib")
+    add_library(${PACK_LIB} STATIC ${ALL_SOURCE_FILES} )
+
+    add_executable( ${ProjectId} ${ALL_SOURCE_FILES} )
+
+    target_link_libraries(${ProjectId} ${PACK_LIB})
+    if( MPI_COMPILE_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES COMPILE_FLAGS "${MPI_COMPILE_FLAGS}" )
+    endif( MPI_COMPILE_FLAGS )
+
+    if( MPI_LINK_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS}" )
+    endif( MPI_LINK_FLAGS )
+    target_link_libraries( ${ProjectId} ${MPI_LIBRARIES} )
+    target_link_libraries(${ProjectId} gtest gtest_main)
+
+    enable_testing()
+    add_test(NAME ${ProjectId} COMMAND ${ProjectId})
+
+    if( UNIX )
+        foreach (SOURCE_FILE ${ALL_SOURCE_FILES})
+            string(FIND ${SOURCE_FILE} ${PROJECT_BINARY_DIR} PROJECT_TRDPARTY_DIR_FOUND)
+            if (NOT ${PROJECT_TRDPARTY_DIR_FOUND} EQUAL -1)
+                list(REMOVE_ITEM ALL_SOURCE_FILES ${SOURCE_FILE})
+            endif ()
+        endforeach ()
+
+        find_program(CPPCHECK cppcheck)
+        add_custom_target(
+                "${ProjectId}_cppcheck" ALL
+                COMMAND ${CPPCHECK}
+                --enable=warning,performance,portability,information,missingInclude
+                --language=c++
+                --std=c++11
+                --error-exitcode=1
+                --template="[{severity}][{id}] {message} {callstack} \(On {file}:{line}\)"
+                --verbose
+                --quiet
+                ${ALL_SOURCE_FILES}
+        )
+    endif( UNIX )
+
+    SET(ARGS_FOR_CHECK_COUNT_TESTS "")
+    foreach (FILE_ELEM ${ALL_SOURCE_FILES})
+        set(ARGS_FOR_CHECK_COUNT_TESTS "${ARGS_FOR_CHECK_COUNT_TESTS} ${FILE_ELEM}")
+    endforeach ()
+
+    add_custom_target("${ProjectId}_check_count_tests" ALL
+            COMMAND "${Python3_EXECUTABLE}"
+                ${CMAKE_SOURCE_DIR}/scripts/check_count_tests.py
+                ${ProjectId}
+                ${ARGS_FOR_CHECK_COUNT_TESTS}
+    )
+else( USE_MPI )
+    message( STATUS "-- ${ProjectId} - NOT BUILD!"  )
+endif( USE_MPI )

--- a/modules/task_3/ustinov_a_multiple_integral_monte_carlo/main.cpp
+++ b/modules/task_3/ustinov_a_multiple_integral_monte_carlo/main.cpp
@@ -1,0 +1,141 @@
+// Copyright 2022 Ustinov A.
+#define _USE_MATH_DEFINES
+#include <math.h>
+#include <gtest/gtest.h>
+#include <vector>
+#include "./multiple_integral_monte_carlo.h"
+#include <gtest-mpi-listener.hpp>
+
+using std::array;
+using std::function;
+using std::exp;
+using std::sin;
+using std::cos;
+
+template <size_t dim>
+void test_monte_carlo(
+        const function<double(array<double, dim>)> &f,
+        const function<bool(array<double, dim>)> &in_region,
+        const array<double[2], dim> &rect,
+        int64_t n,
+        double expected_answer,
+        double epsilon) {
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    double obtained_answer = multiple_integral_monte_carlo_parallel<dim>(
+                                f, in_region, rect, n);
+    if (rank == 0) {
+        ASSERT_NEAR(obtained_answer, expected_answer, epsilon);
+    }
+}
+
+
+TEST(Monte_Carlo_Multiple_Integral_MPI, Test_1) {
+    // 1 dimension, function - '1', region - '[0; 0.5]'
+    // The answer is 0.5
+    auto f = [](const array<double, 1> &x) -> double {
+        return 1.0;
+    };
+    auto region = [](const array<double, 1> &x) -> bool {
+        return x[0] >= 0.0 && x[0] <= 0.5;
+    };
+    array<double[2], 1> rect;
+    rect[0][0] = 0.0, rect[0][1] = 1.0;
+
+    for (int i = 0; i < 3; ++i) {
+        test_monte_carlo<1>(f, region, rect, 100000000, 0.5, 1e-4);
+    }
+}
+
+TEST(Monte_Carlo_Multiple_Integral_MPI, Test_2) {
+    // 1 dimension, function - '1/(1 + x^2)', region - '[0; 1]'
+    // The answer is 'pi/4'
+    auto f = [](const array<double, 1> &x) -> double {
+        return 1.0/(1.0 + x[0]*x[0]);
+    };
+    auto region = [](const array<double, 1> &x) -> bool {
+        return x[0] >= 0.0 && x[0] <= 1.0;
+    };
+    array<double[2], 1> rect;
+    rect[0][0] = 0.0, rect[0][1] = 1.0;
+
+    for (int i = 0; i < 3; ++i) {
+        test_monte_carlo<1>(f, region, rect, 100000000, M_PI_4, 5e-5);
+    }
+}
+
+TEST(Monte_Carlo_Multiple_Integral_MPI, Test_3) {
+	// 2 dimension, function - '1 - x^2 - y^2', region - 'x^2 + y^2 <= 1'
+    // The answer is 'pi/4'
+    auto f = [](const array<double, 2> &x) -> double {
+        return 1.0 - x[0]*x[0] - x[1]*x[1];
+    };
+    auto region = [](const array<double, 2> &x) -> bool {
+        return x[0]*x[0] + x[1]*x[1] <= 1.0;
+    };
+    array<double[2], 2> rect;
+    rect[0][0] = -1.0, rect[0][1] = 1.0;
+	rect[1][0] = -1.0, rect[1][1] = 1.0;
+
+    for (int i = 0; i < 3; ++i) {
+        test_monte_carlo<2>(f, region, rect, 100000000, M_PI_2, 3e-4);
+    }
+}
+
+TEST(Monte_Carlo_Multiple_Integral_MPI, Test_4) {
+	// 2 dimension, function - 'e^(-(x^2 + y^2))',
+    // region - '0 <= x <= 1, 0 <= y <= 1'
+    // The answer is approximately '0.557746'
+    auto f = [](const array<double, 2> &x) -> double {
+        return exp(-(x[0]*x[0] + x[1]*x[1]));
+    };
+    auto region = [](const array<double, 2> &x) -> bool {
+        return 0.0 <= x[0] && x[0] <= 1.0 && 0.0 <= x[1] && x[1] <= 1.0;
+    };
+    array<double[2], 2> rect;
+    rect[0][0] = 0.0, rect[0][1] = 1.0;
+	rect[1][0] = 0.0, rect[1][1] = 1.0;
+
+    for (int i = 0; i < 3; ++i) {
+        test_monte_carlo<2>(f, region, rect, 100000000, 0.557746, 2e-4);
+    }
+}
+
+TEST(Monte_Carlo_Multiple_Integral_MPI, Test_5) {
+    // 3 dimension, function - 'xyz(1-x-y-z)',
+    // region - 'x >= 0, y >= 0, z >= 0, x + y + z <= 1'
+    // The answer is approximately '0.557746'
+    auto f = [](const array<double, 3> &x) -> double {
+        return x[0]*x[1]*x[2]*(1.0 - x[0] - x[1] - x[2]);
+    };
+    auto region = [](const array<double, 3> &x) -> bool {
+        return x[0] >= 0.0 && x[1] >= 0.0 && x[2] >= 0.0 &&
+               x[0] + x[1] + x[2] <= 1.0;
+    };
+    array<double[2], 3> rect;
+    rect[0][0] = 0.0, rect[0][1] = 1.0;
+    rect[1][0] = 0.0, rect[1][1] = 1.0;
+    rect[2][0] = 0.0, rect[2][1] = 1.0;
+
+    for (int i = 0; i < 3; ++i) {
+        test_monte_carlo<3>(f, region, rect, 100000000,
+                            0.00000275573192239, 2e-4);
+    }
+}
+
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    MPI_Init(&argc, &argv);
+
+    ::testing::AddGlobalTestEnvironment(new GTestMPIListener::MPIEnvironment);
+    ::testing::TestEventListeners& listeners =
+        ::testing::UnitTest::GetInstance()->listeners();
+
+    listeners.Release(listeners.default_result_printer());
+    listeners.Release(listeners.default_xml_generator());
+
+    listeners.Append(new GTestMPIListener::MPIMinimalistPrinter);
+    return RUN_ALL_TESTS();
+}

--- a/modules/task_3/ustinov_a_multiple_integral_monte_carlo/main.cpp
+++ b/modules/task_3/ustinov_a_multiple_integral_monte_carlo/main.cpp
@@ -66,7 +66,7 @@ TEST(Monte_Carlo_Multiple_Integral_MPI, Test_2) {
 }
 
 TEST(Monte_Carlo_Multiple_Integral_MPI, Test_3) {
-	// 2 dimension, function - '1 - x^2 - y^2', region - 'x^2 + y^2 <= 1'
+    // 2 dimension, function - '1 - x^2 - y^2', region - 'x^2 + y^2 <= 1'
     // The answer is 'pi/4'
     auto f = [](const array<double, 2> &x) -> double {
         return 1.0 - x[0]*x[0] - x[1]*x[1];
@@ -76,7 +76,7 @@ TEST(Monte_Carlo_Multiple_Integral_MPI, Test_3) {
     };
     array<double[2], 2> rect;
     rect[0][0] = -1.0, rect[0][1] = 1.0;
-	rect[1][0] = -1.0, rect[1][1] = 1.0;
+    rect[1][0] = -1.0, rect[1][1] = 1.0;
 
     for (int i = 0; i < 3; ++i) {
         test_monte_carlo<2>(f, region, rect, 100000000, M_PI_2, 3e-4);
@@ -84,7 +84,7 @@ TEST(Monte_Carlo_Multiple_Integral_MPI, Test_3) {
 }
 
 TEST(Monte_Carlo_Multiple_Integral_MPI, Test_4) {
-	// 2 dimension, function - 'e^(-(x^2 + y^2))',
+    // 2 dimension, function - 'e^(-(x^2 + y^2))',
     // region - '0 <= x <= 1, 0 <= y <= 1'
     // The answer is approximately '0.557746'
     auto f = [](const array<double, 2> &x) -> double {
@@ -95,7 +95,7 @@ TEST(Monte_Carlo_Multiple_Integral_MPI, Test_4) {
     };
     array<double[2], 2> rect;
     rect[0][0] = 0.0, rect[0][1] = 1.0;
-	rect[1][0] = 0.0, rect[1][1] = 1.0;
+    rect[1][0] = 0.0, rect[1][1] = 1.0;
 
     for (int i = 0; i < 3; ++i) {
         test_monte_carlo<2>(f, region, rect, 100000000, 0.557746, 2e-4);

--- a/modules/task_3/ustinov_a_multiple_integral_monte_carlo/main.cpp
+++ b/modules/task_3/ustinov_a_multiple_integral_monte_carlo/main.cpp
@@ -43,7 +43,7 @@ TEST(Monte_Carlo_Multiple_Integral_MPI, Test_1) {
     array<double[2], 1> rect;
     rect[0][0] = 0.0, rect[0][1] = 1.0;
 
-    test_monte_carlo<1>(f, region, rect, 30000000, 0.5, 2e-4);
+    test_monte_carlo<1>(f, region, rect, 30000000, 0.5, 3e-4);
 }
 
 TEST(Monte_Carlo_Multiple_Integral_MPI, Test_2) {
@@ -74,7 +74,7 @@ TEST(Monte_Carlo_Multiple_Integral_MPI, Test_3) {
     rect[0][0] = -1.0, rect[0][1] = 1.0;
     rect[1][0] = -1.0, rect[1][1] = 1.0;
 
-    test_monte_carlo<2>(f, region, rect, 3000000, M_PI_2, 2e-3);
+    test_monte_carlo<2>(f, region, rect, 3000000, M_PI_2, 3e-3);
 }
 
 TEST(Monte_Carlo_Multiple_Integral_MPI, Test_4) {

--- a/modules/task_3/ustinov_a_multiple_integral_monte_carlo/main.cpp
+++ b/modules/task_3/ustinov_a_multiple_integral_monte_carlo/main.cpp
@@ -43,9 +43,7 @@ TEST(Monte_Carlo_Multiple_Integral_MPI, Test_1) {
     array<double[2], 1> rect;
     rect[0][0] = 0.0, rect[0][1] = 1.0;
 
-    for (int i = 0; i < 3; ++i) {
-        test_monte_carlo<1>(f, region, rect, 100000000, 0.5, 1e-4);
-    }
+    test_monte_carlo<1>(f, region, rect, 30000000, 0.5, 2e-4);
 }
 
 TEST(Monte_Carlo_Multiple_Integral_MPI, Test_2) {
@@ -60,9 +58,7 @@ TEST(Monte_Carlo_Multiple_Integral_MPI, Test_2) {
     array<double[2], 1> rect;
     rect[0][0] = 0.0, rect[0][1] = 1.0;
 
-    for (int i = 0; i < 3; ++i) {
-        test_monte_carlo<1>(f, region, rect, 100000000, M_PI_4, 5e-5);
-    }
+    test_monte_carlo<1>(f, region, rect, 30000000, M_PI_4, 3e-4);
 }
 
 TEST(Monte_Carlo_Multiple_Integral_MPI, Test_3) {
@@ -78,9 +74,7 @@ TEST(Monte_Carlo_Multiple_Integral_MPI, Test_3) {
     rect[0][0] = -1.0, rect[0][1] = 1.0;
     rect[1][0] = -1.0, rect[1][1] = 1.0;
 
-    for (int i = 0; i < 3; ++i) {
-        test_monte_carlo<2>(f, region, rect, 100000000, M_PI_2, 3e-4);
-    }
+    test_monte_carlo<2>(f, region, rect, 3000000, M_PI_2, 2e-3);
 }
 
 TEST(Monte_Carlo_Multiple_Integral_MPI, Test_4) {
@@ -97,9 +91,7 @@ TEST(Monte_Carlo_Multiple_Integral_MPI, Test_4) {
     rect[0][0] = 0.0, rect[0][1] = 1.0;
     rect[1][0] = 0.0, rect[1][1] = 1.0;
 
-    for (int i = 0; i < 3; ++i) {
-        test_monte_carlo<2>(f, region, rect, 100000000, 0.557746, 2e-4);
-    }
+    test_monte_carlo<2>(f, region, rect, 30000000, 0.557746, 2e-4);
 }
 
 TEST(Monte_Carlo_Multiple_Integral_MPI, Test_5) {
@@ -118,10 +110,7 @@ TEST(Monte_Carlo_Multiple_Integral_MPI, Test_5) {
     rect[1][0] = 0.0, rect[1][1] = 1.0;
     rect[2][0] = 0.0, rect[2][1] = 1.0;
 
-    for (int i = 0; i < 3; ++i) {
-        test_monte_carlo<3>(f, region, rect, 100000000,
-                            0.00000275573192239, 2e-4);
-    }
+    test_monte_carlo<3>(f, region, rect, 30000000, 1.0/5040.0, 2e-5);
 }
 
 

--- a/modules/task_3/ustinov_a_multiple_integral_monte_carlo/multiple_integral_monte_carlo.h
+++ b/modules/task_3/ustinov_a_multiple_integral_monte_carlo/multiple_integral_monte_carlo.h
@@ -45,7 +45,7 @@ double multiple_integral_monte_carlo_parallel(
             corrected_sum = local_sum + corrected_value;
             error_sum = (corrected_sum - local_sum) - corrected_value;
             local_sum = corrected_sum;
-			//local_sum += multiplier * f(random_point);
+            // local_sum += multiplier * f(random_point);
         }
     }
 

--- a/modules/task_3/ustinov_a_multiple_integral_monte_carlo/multiple_integral_monte_carlo.h
+++ b/modules/task_3/ustinov_a_multiple_integral_monte_carlo/multiple_integral_monte_carlo.h
@@ -1,0 +1,91 @@
+// Copyright 2022 Ustinov A.
+#ifndef MODULES_TASK_3_USTINOV_A_MULTIPLE_INTEGRAL_MONTE_CARLO_MULTIPLE_INTEGRAL_MONTE_CARLO_H_
+#define MODULES_TASK_3_USTINOV_A_MULTIPLE_INTEGRAL_MONTE_CARLO_MULTIPLE_INTEGRAL_MONTE_CARLO_H_
+
+#include <mpi.h>
+#include <cstdint>
+#include <array>
+#include <functional>
+#include <random>
+
+template <size_t dim>
+double multiple_integral_monte_carlo_parallel(
+        const std::function<double(std::array<double, dim>)> &f,
+        const std::function<bool(std::array<double, dim>)> &in_region,
+        const std::array<double[2], dim> &rect,
+        int64_t n) {
+    int rank;  // number of current process
+    int size;  // total number of processes
+    int64_t n_per_process;  // number of iterations for current process
+    double local_sum = 0.0;  // answer in each process
+    double total_sum = 0.0;  // total answer is a sum of local answers
+    double multiplier = 1/static_cast<double>(n);  // multiplier in sum
+    double current_value;    // term to add to 'local_sum'
+    double corrected_value;  // 'current_value' corrected by 'error_sum'
+    double error_sum = 0.0;  // current sum of errors of computations
+    double corrected_sum;    // 'local_sum' + 'corrected_value'
+    std::array<double, dim> random_point;  // random point in rectangle
+    std::mt19937_64 generator{std::random_device {}()};
+    std::uniform_real_distribution<double> distribution(0.0, 1.0);
+
+    for (size_t i = 0; i < dim; ++i)
+        multiplier *= (rect[i][1] - rect[i][0]);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    n_per_process = ((rank + 1) * n) / size - (rank * n) / size;
+
+    for (int64_t it = 0; it < n_per_process; ++it) {
+        for (size_t i = 0; i < dim; ++i)
+            random_point[i] = rect[i][0] +  // carried
+            (rect[i][1] - rect[i][0]) * distribution(generator);
+        if (in_region(random_point)) {
+            // Cahan's algorithm to increace answer's precision
+            current_value = multiplier * f(random_point);
+            corrected_value = current_value - error_sum;
+            corrected_sum = local_sum + corrected_value;
+            error_sum = (corrected_sum - local_sum) - corrected_value;
+            local_sum = corrected_sum;
+        }
+    }
+
+    MPI_Reduce(&local_sum, &total_sum, 1, MPI_DOUBLE,  // carried
+               MPI_SUM, 0, MPI_COMM_WORLD);
+    return total_sum;
+}
+template <size_t dim>
+double multiple_integral_monte_carlo_sequential(
+        const std::function<double(std::array<double, dim>)> &f,
+        const std::function<bool(std::array<double, dim>)> &in_region,
+        const std::array<double[2], dim> &rect,
+        int64_t n) {
+    double total_sum = 0.0;  // result of computations
+    double multiplier = 1/static_cast<double>(n);  // multiplier in sum
+    double current_value;    // term to add to 'total_sum'
+    double corrected_value;  // 'current_value' corrected by 'error_sum'
+    double error_sum = 0.0;  // current sum of errors of computations
+    double corrected_sum;    // 'total_sum' + 'corrected_value'
+    std::array<double, dim> random_point;  // random point in rectangle
+    std::mt19937_64 generator{std::random_device {}()};  // random number generator
+    std::uniform_real_distribution<double> distribution(0.0, 1.0);
+
+    for (size_t i = 0; i < dim; ++i)
+        multiplier *= (rect[i][1] - rect[i][0]);
+
+    for (int64_t it = 0; it < n; ++it) {
+        for (size_t i = 0; i < dim; ++i)
+            random_point[i] = rect[i][0] +  // carried
+            (rect[i][1] - rect[i][0]) * distribution(generator);
+        if (in_region(random_point)) {
+            // Cahan's algorithm to increace answer's precision
+            current_value = multiplier * f(random_point);
+            corrected_value = current_value - error_sum;
+            corrected_sum = total_sum + corrected_value;
+            error_sum = (corrected_sum - total_sum) - corrected_value;
+            total_sum = corrected_sum;
+        }
+    }
+
+    return total_sum;
+}
+
+#endif  // MODULES_TASK_3_USTINOV_A_MULTIPLE_INTEGRAL_MONTE_CARLO_MULTIPLE_INTEGRAL_MONTE_CARLO_H_

--- a/modules/task_3/ustinov_a_multiple_integral_monte_carlo/multiple_integral_monte_carlo.h
+++ b/modules/task_3/ustinov_a_multiple_integral_monte_carlo/multiple_integral_monte_carlo.h
@@ -45,6 +45,7 @@ double multiple_integral_monte_carlo_parallel(
             corrected_sum = local_sum + corrected_value;
             error_sum = (corrected_sum - local_sum) - corrected_value;
             local_sum = corrected_sum;
+			//local_sum += multiplier * f(random_point);
         }
     }
 


### PR DESCRIPTION
Метод Монте-Карло позволяет вычислять кратные интегралы (N-мерные) по произвольной ограниченной области N-мерного пространства. 
Принцип работы. Допустим, что область лежит внутри известного N-мерного параллелепипеда, есть непрерывное распределение вероятности, плотность которого "p" равна 0 вне параллелепипеда, а "f" - подынтегральная функция, доопределённая как 0 вне области. 
Тогда int(f) = int(f/p * p) = M(f/p), т.е. интеграл равен матожиданию значения функции, делённого на плотность вероятности. Если многократно брать случайные точки "x_i" в параллелепипеде, можно посчитать среднее арифметическое полученных значений "(f/p)(x_i)", которое будет приближением "f/p". 
Доказано, что погрешность метода при "n" испытаниях составляет O(1/√n), потому она убывает достаточно медленно. Тем не менее, метод полезен в тех случаях, когда не требуется знать значение интеграла с высокой точностью.